### PR TITLE
simplify toHash

### DIFF
--- a/src/react/Content/src/Global.fs
+++ b/src/react/Content/src/Global.fs
@@ -5,8 +5,8 @@ type Page =
   | Counter
   | About
 
-let toHash =
-  function
+let toHash page =
+  match page with
   | About -> "#about"
   | Counter -> "#counter"
   | Home -> "#home"


### PR DESCRIPTION
we should not use `function` in samples. Just stcik to simple pattern match.