### PR TITLE
Prevents toggle type conflict with Fable template

### DIFF
--- a/src/react/Content/.template.config/template.json
+++ b/src/react/Content/.template.config/template.json
@@ -1,13 +1,13 @@
 {
   "author": "Maxime Mangel",
-  "classifications": [ "Fable" ],
+  "classifications": [ "Fable", "Elmish", "React" ],
   "name": "Fable.Elmish.React App",
   "tags": {
     "language": "F#",
     "type": "project"
   },
   "identity": "Fable.Template.Elmish.React",
-  "groupIdentity": "Fable",
+  "groupIdentity": "FableElmishReact",
   "shortName": "fable-elmish-react",
   "sourceName": "FableElmishReactTemplate",
   // This allows using the `-n` option to create a new directory


### PR DESCRIPTION
Expected:  Installing template has no impact on regular Fable template
Actual:  Installing Fable template hides this one and vice versa when listing templates with dotnet new -l