### PR TITLE
Added Fable.Template vscode tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 npm-debug.log
 samples/**/public
 
-.vscode/
+/.vscode/
 
 # F#
 .fake/

--- a/src/react-demo/Content/.vscode/tasks.json
+++ b/src/react-demo/Content/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "dotnet",
+    "runner": "terminal",
+    "args": [],
+    "options": {
+        "cwd": "${workspaceRoot}/src"
+    },
+    "tasks": [
+        {
+            "taskName": "Start",
+            "args": ["fable", "yarn-run", "start" ],
+            "isBuildCommand": true,
+            "suppressTaskName": true,
+            "isBackground": true,
+            "problemMatcher": {
+                "fileLocation": "absolute",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern":{
+                        "regexp": "webpack: Compiling"
+                    },
+                    "endsPattern":{
+                        "regexp": "webpack: (Compiled successfully|Failed to compile)"
+                    }
+                },
+                "pattern": {
+                    "regexp": "^(.*)\\((\\d+),(\\d+)\\): \\((\\d+),(\\d+)\\) (warning|error) FABLE: (.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "endLine": 4,
+                    "endColumn": 5,
+                    "severity": 6,
+                    "message": 7
+                }
+            }
+        }
+    ]
+}

--- a/src/react/Content/.vscode/tasks.json
+++ b/src/react/Content/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "dotnet",
+    "runner": "terminal",
+    "args": [],
+    "options": {
+        "cwd": "${workspaceRoot}/src"
+    },
+    "tasks": [
+        {
+            "taskName": "Start",
+            "args": ["fable", "yarn-run", "start" ],
+            "isBuildCommand": true,
+            "suppressTaskName": true,
+            "isBackground": true,
+            "problemMatcher": {
+                "fileLocation": "absolute",
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern":{
+                        "regexp": "webpack: Compiling"
+                    },
+                    "endsPattern":{
+                        "regexp": "webpack: (Compiled successfully|Failed to compile)"
+                    }
+                },
+                "pattern": {
+                    "regexp": "^(.*)\\((\\d+),(\\d+)\\): \\((\\d+),(\\d+)\\) (warning|error) FABLE: (.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "endLine": 4,
+                    "endColumn": 5,
+                    "severity": 6,
+                    "message": 7
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added vscode tasks so that `ctrl + shift + b` runs `dotnet fable yarn-start` [consistent with the latest Fable.Template](https://github.com/fable-compiler/fable-templates/blob/master/simple/Content/README.md)

Adjusted top level .gitignore to allow .vscode subdirectories but not .vscode top directory. Previously all .vscode directories disallowed.